### PR TITLE
従業員詳細画面の入社日と給料の表示形式を変更しました

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.hireDate}">2012/11/29</span>
+                      <span th:utext="${#dates.format(employee.hireDate, yyyy年MM月dd日)}">2012/11/29</span>
                     </td>
                   </tr>
                   <tr>
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:utext="${#numbers.formatInteger(employee.salary, 1, 'COMMA') + '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${#dates.format(employee.hireDate, yyyy年MM月dd日)}">2012/11/29</span>
+                      <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012/11/29</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
お疲れ様です！
従業員詳細画面の入社日と給料の表示形式を変更したので確認お願いします。(スプレッドシートの4-1と4-2の内容を同時にpushしています！)

## 修正内容
- detail.htmlの入社日の表示部分を#datesを使用して「yyyy年MM月dd日」と表示されるよう修正しました
- detail.htmlの給料の表示部分を#numbersを使用して1000の区切りを,（カンマ）で表示されるよう修正しました